### PR TITLE
Add settings to modify the metadata

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,8 +1,65 @@
 {
   "jupyter.lab.shortcuts": [],
-  "title": "nb-metadata-handler",
-  "description": "nb-metadata-handler settings.",
+  "title": "Notebook metadata handler",
+  "description": "Handle metadata of inserted cells",
   "type": "object",
-  "properties": {},
-  "additionalProperties": false
+  "properties": {
+    "handlers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/action"
+      },
+      "default": []
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "insertMethod": {
+      "type": "string",
+      "enum": [
+        "all",
+        "copyPaste",
+        "cutPaste",
+        "new"
+      ]
+    },
+    "action": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "The action to perform on metadata",
+          "enum": [
+            "add",
+            "delete"
+          ],
+          "default": "add"
+        },
+        "method": {
+          "description": "The method used to insert the cell",
+          "$ref": "#/definitions/insertMethod",
+          "default": "all"
+        },
+        "path": {
+          "type": "string",
+          "title": "Metadata path",
+          "description": "The path to the metadata (should not start with '/')"
+        }
+      },
+      "if": {
+        "properties": {
+          "action": { "const": "add" }
+        }
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "description": "The value to add",
+            "type": "string"
+          }
+        }
+      },
+      "required": ["action", "method"]
+    }
+  }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -16,12 +16,7 @@
   "definitions": {
     "insertMethod": {
       "type": "string",
-      "enum": [
-        "all",
-        "copyPaste",
-        "cutPaste",
-        "new"
-      ]
+      "enum": ["all", "copyPaste", "cutPaste", "new"]
     },
     "action": {
       "type": "object",
@@ -29,10 +24,7 @@
         "action": {
           "type": "string",
           "description": "The action to perform on metadata",
-          "enum": [
-            "add",
-            "delete"
-          ],
+          "enum": ["add", "delete"],
           "default": "add"
         },
         "method": {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -12,14 +12,15 @@ export class MetadataHandlerRegistry implements IMetadataHandlerRegistry {
    * Add a new metadata handler.
    * No-op if the same is already registered.
    */
-  add(handler: IMetadataHandler): void {
+  add(handler: IMetadataHandler): boolean {
     const index = this._metadataHandlers.findIndex(
       h => h.action === handler.action && h.path === handler.path
     );
     if (index !== -1) {
-      return;
+      return false;
     }
     this._metadataHandlers.push(handler);
+    return true;
   }
 
   /**

--- a/src/token.ts
+++ b/src/token.ts
@@ -62,7 +62,7 @@ export interface IMetadataHandlerRegistry {
    * Add a new metadata handler.
    * No-op if the same is already registered.
    */
-  add(handler: IMetadataHandler): void;
+  add(handler: IMetadataHandler): boolean;
   /**
    * Remove a metadata handler.
    */


### PR DESCRIPTION
This PR allows adding cell metadata handlers from the settings.

For an handler that should add metadata, the value can be either boolean, number, string, object or array.
The corresponding field in the settings form is a simple string input.


In a future PR, we may want to have a custom widget to handle JSON data, like the cell/notebook metadata editor in advanced tools.

<img src=https://github.com/user-attachments/assets/f9357944-9bac-428c-9c99-de01f76a66c3 width=300px>
